### PR TITLE
Haitao/bump api version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-linkedin-ads',
-      version='2.3.1',
+      version='2.4.0',
       description='Singer.io tap for extracting data from the LinkedIn Marketing Ads API API 2.0',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_linkedin_ads'],
       install_requires=[
-          'backoff==1.8.0',
-          'requests==2.22.0',
-          'singer-python==5.12.1'
+          'backoff==2.2.1',
+          'requests==2.32.3',
+          'singer-python==6.1.0'
       ],
       extras_require={
         'dev': [

--- a/tap_linkedin_ads/client.py
+++ b/tap_linkedin_ads/client.py
@@ -12,7 +12,7 @@ LOGGER = singer.get_logger()
 BASE_URL = 'https://api.linkedin.com/rest'
 LINKEDIN_TOKEN_URI = 'https://www.linkedin.com/oauth/v2/accessToken'
 INTROSPECTION_URI = 'https://www.linkedin.com/oauth/v2/introspectToken'
-LINKEDIN_VERSION = '202403'
+LINKEDIN_VERSION = '202501'
 
 # set default timeout of 300 seconds
 REQUEST_TIMEOUT = 300


### PR DESCRIPTION
API version 202403 has been sunset on March 17th, 2023. 
We need to bump the version of this library.
